### PR TITLE
Fix *All method which return a channel

### DIFF
--- a/api_account.go
+++ b/api_account.go
@@ -243,7 +243,7 @@ func (c *apiClient) AccountRewardsHistory(ctx context.Context, stakeAddress stri
 func (c *apiClient) AccountRewardsHistoryAll(ctx context.Context, stakeAddress string) <-chan AccountRewardHisResult {
 	ch := make(chan AccountRewardHisResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -254,7 +254,10 @@ func (c *apiClient) AccountRewardsHistoryAll(ctx context.Context, stakeAddress s
 			for j := range jobs {
 				his, err := c.AccountRewardsHistory(j.ctx, stakeAddress, j.query)
 				if len(his) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := AccountRewardHisResult{Res: his, Err: err}
 				ch <- res
@@ -269,12 +272,12 @@ func (c *apiClient) AccountRewardsHistoryAll(ctx context.Context, stakeAddress s
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch
@@ -312,7 +315,7 @@ func (c *apiClient) AccountHistory(ctx context.Context, stakeAddress string, que
 func (c *apiClient) AccountHistoryAll(ctx context.Context, address string) <-chan AccountHistoryResult {
 	ch := make(chan AccountHistoryResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -323,7 +326,10 @@ func (c *apiClient) AccountHistoryAll(ctx context.Context, address string) <-cha
 			for j := range jobs {
 				his, err := c.AccountHistory(j.ctx, address, j.query)
 				if len(his) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := AccountHistoryResult{Res: his, Err: err}
 				ch <- res
@@ -338,12 +344,12 @@ func (c *apiClient) AccountHistoryAll(ctx context.Context, address string) <-cha
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch
@@ -381,7 +387,7 @@ func (c *apiClient) AccountDelegationHistory(ctx context.Context, stakeAddress s
 func (c *apiClient) AccountDelegationHistoryAll(ctx context.Context, stakeAddress string) <-chan AccDelegationHistoryResult {
 	ch := make(chan AccDelegationHistoryResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -392,7 +398,10 @@ func (c *apiClient) AccountDelegationHistoryAll(ctx context.Context, stakeAddres
 			for j := range jobs {
 				his, err := c.AccountDelegationHistory(j.ctx, stakeAddress, j.query)
 				if len(his) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := AccDelegationHistoryResult{Res: his, Err: err}
 				ch <- res
@@ -407,12 +416,12 @@ func (c *apiClient) AccountDelegationHistoryAll(ctx context.Context, stakeAddres
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch
@@ -450,7 +459,7 @@ func (c *apiClient) AccountRegistrationHistory(ctx context.Context, stakeAddress
 func (c *apiClient) AccountRegistrationHistoryAll(ctx context.Context, stakeAddress string) <-chan AccountRegistrationHistoryResult {
 	ch := make(chan AccountRegistrationHistoryResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -461,7 +470,10 @@ func (c *apiClient) AccountRegistrationHistoryAll(ctx context.Context, stakeAddr
 			for j := range jobs {
 				his, err := c.AccountRegistrationHistory(j.ctx, stakeAddress, j.query)
 				if len(his) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := AccountRegistrationHistoryResult{Res: his, Err: err}
 				ch <- res
@@ -476,12 +488,12 @@ func (c *apiClient) AccountRegistrationHistoryAll(ctx context.Context, stakeAddr
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch
@@ -519,7 +531,7 @@ func (c *apiClient) AccountWithdrawalHistory(ctx context.Context, stakeAddress s
 func (c *apiClient) AccountWithdrawalHistoryAll(ctx context.Context, stakeAddress string) <-chan AccountWithdrawalHistoryResult {
 	ch := make(chan AccountWithdrawalHistoryResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -530,7 +542,10 @@ func (c *apiClient) AccountWithdrawalHistoryAll(ctx context.Context, stakeAddres
 			for j := range jobs {
 				his, err := c.AccountWithdrawalHistory(j.ctx, stakeAddress, j.query)
 				if len(his) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := AccountWithdrawalHistoryResult{Res: his, Err: err}
 				ch <- res
@@ -545,12 +560,12 @@ func (c *apiClient) AccountWithdrawalHistoryAll(ctx context.Context, stakeAddres
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch
@@ -588,7 +603,7 @@ func (c *apiClient) AccountMIRHistory(ctx context.Context, stakeAddress string, 
 func (c *apiClient) AccountMIRHistoryAll(ctx context.Context, stakeAddress string) <-chan AccountMIRHistoryResult {
 	ch := make(chan AccountMIRHistoryResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -599,7 +614,10 @@ func (c *apiClient) AccountMIRHistoryAll(ctx context.Context, stakeAddress strin
 			for j := range jobs {
 				his, err := c.AccountMIRHistory(j.ctx, stakeAddress, j.query)
 				if len(his) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := AccountMIRHistoryResult{Res: his, Err: err}
 				ch <- res
@@ -614,12 +632,12 @@ func (c *apiClient) AccountMIRHistoryAll(ctx context.Context, stakeAddress strin
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch
@@ -656,7 +674,7 @@ func (c *apiClient) AccountAssociatedAddresses(ctx context.Context, stakeAddress
 func (c *apiClient) AccountAssociatedAddressesAll(ctx context.Context, stakeAddress string) <-chan AccountAssociatedAddressesAll {
 	ch := make(chan AccountAssociatedAddressesAll, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -667,7 +685,10 @@ func (c *apiClient) AccountAssociatedAddressesAll(ctx context.Context, stakeAddr
 			for j := range jobs {
 				addrs, err := c.AccountAssociatedAddresses(j.ctx, stakeAddress, j.query)
 				if len(addrs) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := AccountAssociatedAddressesAll{Res: addrs, Err: err}
 				ch <- res
@@ -682,12 +703,12 @@ func (c *apiClient) AccountAssociatedAddressesAll(ctx context.Context, stakeAddr
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch
@@ -725,7 +746,7 @@ func (c *apiClient) AccountAssociatedAssets(ctx context.Context, stakeAddress st
 func (c *apiClient) AccountAssociatedAssetsAll(ctx context.Context, stakeAddress string) <-chan AccountAssociatedAssetsAll {
 	ch := make(chan AccountAssociatedAssetsAll, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -736,7 +757,10 @@ func (c *apiClient) AccountAssociatedAssetsAll(ctx context.Context, stakeAddress
 			for j := range jobs {
 				as, err := c.AccountAssociatedAssets(j.ctx, stakeAddress, j.query)
 				if len(as) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := AccountAssociatedAssetsAll{Res: as, Err: err}
 				ch <- res
@@ -751,12 +775,12 @@ func (c *apiClient) AccountAssociatedAssetsAll(ctx context.Context, stakeAddress
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch

--- a/api_epochs.go
+++ b/api_epochs.go
@@ -233,7 +233,7 @@ func (c *apiClient) EpochsNext(ctx context.Context, epochNumber int, query APIQu
 func (c *apiClient) EpochNextAll(ctx context.Context, epochNumber int) <-chan EpochResult {
 	ch := make(chan EpochResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -244,7 +244,10 @@ func (c *apiClient) EpochNextAll(ctx context.Context, epochNumber int) <-chan Ep
 			for j := range jobs {
 				as, err := c.EpochsNext(j.ctx, epochNumber, j.query)
 				if len(as) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := EpochResult{Res: as, Err: err}
 				ch <- res
@@ -259,12 +262,12 @@ func (c *apiClient) EpochNextAll(ctx context.Context, epochNumber int) <-chan Ep
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch
@@ -301,7 +304,7 @@ func (c *apiClient) EpochsPrevious(ctx context.Context, epochNumber int, query A
 func (c *apiClient) EpochPreviousAll(ctx context.Context, epochNumber int) <-chan EpochResult {
 	ch := make(chan EpochResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -312,7 +315,10 @@ func (c *apiClient) EpochPreviousAll(ctx context.Context, epochNumber int) <-cha
 			for j := range jobs {
 				as, err := c.EpochsPrevious(j.ctx, epochNumber, j.query)
 				if len(as) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := EpochResult{Res: as, Err: err}
 				ch <- res
@@ -327,12 +333,12 @@ func (c *apiClient) EpochPreviousAll(ctx context.Context, epochNumber int) <-cha
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch
@@ -369,7 +375,7 @@ func (c *apiClient) EpochStakeDistribution(ctx context.Context, epochNumber int,
 func (c *apiClient) EpochStakeDistributionAll(ctx context.Context, epochNumber int) <-chan EpochStakeResult {
 	ch := make(chan EpochStakeResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -380,7 +386,10 @@ func (c *apiClient) EpochStakeDistributionAll(ctx context.Context, epochNumber i
 			for j := range jobs {
 				eps, err := c.EpochStakeDistribution(j.ctx, epochNumber, j.query)
 				if len(eps) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := EpochStakeResult{Res: eps, Err: err}
 				ch <- res
@@ -395,12 +404,12 @@ func (c *apiClient) EpochStakeDistributionAll(ctx context.Context, epochNumber i
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch
@@ -437,7 +446,7 @@ func (c *apiClient) EpochStakeDistributionByPool(ctx context.Context, epochNumbe
 func (c *apiClient) EpochStakeDistributionByPoolAll(ctx context.Context, epochNumber int, poolId string) <-chan EpochStakeResult {
 	ch := make(chan EpochStakeResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -448,7 +457,10 @@ func (c *apiClient) EpochStakeDistributionByPoolAll(ctx context.Context, epochNu
 			for j := range jobs {
 				eps, err := c.EpochStakeDistributionByPool(j.ctx, epochNumber, poolId, j.query)
 				if len(eps) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := EpochStakeResult{Res: eps, Err: err}
 				ch <- res
@@ -463,12 +475,12 @@ func (c *apiClient) EpochStakeDistributionByPoolAll(ctx context.Context, epochNu
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch
@@ -505,7 +517,7 @@ func (c *apiClient) EpochBlockDistribution(ctx context.Context, epochNumber int,
 func (c *apiClient) EpochBlockDistributionAll(ctx context.Context, epochNumber int) <-chan BlockDistributionResult {
 	ch := make(chan BlockDistributionResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -516,7 +528,10 @@ func (c *apiClient) EpochBlockDistributionAll(ctx context.Context, epochNumber i
 			for j := range jobs {
 				eps, err := c.EpochBlockDistribution(j.ctx, epochNumber, j.query)
 				if len(eps) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := BlockDistributionResult{Res: eps, Err: err}
 				ch <- res
@@ -531,12 +546,12 @@ func (c *apiClient) EpochBlockDistributionAll(ctx context.Context, epochNumber i
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch
@@ -573,7 +588,7 @@ func (c *apiClient) EpochBlockDistributionByPool(ctx context.Context, epochNumbe
 func (c *apiClient) EpochBlockDistributionByPoolAll(ctx context.Context, epochNumber int, poolId string) <-chan BlockDistributionResult {
 	ch := make(chan BlockDistributionResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -584,7 +599,10 @@ func (c *apiClient) EpochBlockDistributionByPoolAll(ctx context.Context, epochNu
 			for j := range jobs {
 				eps, err := c.EpochBlockDistributionByPool(j.ctx, epochNumber, poolId, j.query)
 				if len(eps) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := BlockDistributionResult{Res: eps, Err: err}
 				ch <- res
@@ -599,12 +617,12 @@ func (c *apiClient) EpochBlockDistributionByPoolAll(ctx context.Context, epochNu
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch

--- a/api_metadata.go
+++ b/api_metadata.go
@@ -90,7 +90,7 @@ func (c *apiClient) MetadataTxLabels(ctx context.Context, query APIQueryParams) 
 func (c *apiClient) MetadataTxLabelsAll(ctx context.Context) <-chan MetadataTxLabelResult {
 	ch := make(chan MetadataTxLabelResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -101,7 +101,10 @@ func (c *apiClient) MetadataTxLabelsAll(ctx context.Context) <-chan MetadataTxLa
 			for j := range jobs {
 				as, err := c.MetadataTxLabels(j.ctx, j.query)
 				if len(as) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := MetadataTxLabelResult{Res: as, Err: err}
 				ch <- res
@@ -116,12 +119,12 @@ func (c *apiClient) MetadataTxLabelsAll(ctx context.Context) <-chan MetadataTxLa
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch
@@ -160,7 +163,7 @@ func (c *apiClient) MetadataTxContentInJSON(ctx context.Context, label string, q
 func (c *apiClient) MetadataTxContentInJSONAll(ctx context.Context, label string) <-chan MetadataTxContentInJSONResult {
 	ch := make(chan MetadataTxContentInJSONResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -171,7 +174,10 @@ func (c *apiClient) MetadataTxContentInJSONAll(ctx context.Context, label string
 			for j := range jobs {
 				tc, err := c.MetadataTxContentInJSON(j.ctx, label, j.query)
 				if len(tc) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := MetadataTxContentInJSONResult{Res: tc, Err: err}
 				ch <- res
@@ -186,12 +192,12 @@ func (c *apiClient) MetadataTxContentInJSONAll(ctx context.Context, label string
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch
@@ -230,7 +236,7 @@ func (c *apiClient) MetadataTxContentInCBOR(ctx context.Context, label string, q
 func (c *apiClient) MetadataTxContentInCBORAll(ctx context.Context, label string) <-chan MetadataTxContentInCBORResult {
 	ch := make(chan MetadataTxContentInCBORResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -241,7 +247,10 @@ func (c *apiClient) MetadataTxContentInCBORAll(ctx context.Context, label string
 			for j := range jobs {
 				tc, err := c.MetadataTxContentInCBOR(j.ctx, label, j.query)
 				if len(tc) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := MetadataTxContentInCBORResult{Res: tc, Err: err}
 				ch <- res
@@ -256,12 +265,12 @@ func (c *apiClient) MetadataTxContentInCBORAll(ctx context.Context, label string
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch

--- a/api_pool.go
+++ b/api_pool.go
@@ -181,7 +181,7 @@ func (c *apiClient) Pools(ctx context.Context, query APIQueryParams) (ps Pools, 
 func (c *apiClient) PoolsAll(ctx context.Context) <-chan PoolsResult {
 	ch := make(chan PoolsResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -192,7 +192,10 @@ func (c *apiClient) PoolsAll(ctx context.Context) <-chan PoolsResult {
 			for j := range jobs {
 				pools, err := c.Pools(j.ctx, j.query)
 				if len(pools) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := PoolsResult{Res: pools, Err: err}
 				ch <- res
@@ -207,12 +210,12 @@ func (c *apiClient) PoolsAll(ctx context.Context) <-chan PoolsResult {
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch
@@ -250,7 +253,7 @@ func (c *apiClient) PoolsRetired(ctx context.Context, query APIQueryParams) (prs
 func (c *apiClient) PoolsRetiredAll(ctx context.Context) <-chan PoolsRetiredResult {
 	ch := make(chan PoolsRetiredResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -261,7 +264,10 @@ func (c *apiClient) PoolsRetiredAll(ctx context.Context) <-chan PoolsRetiredResu
 			for j := range jobs {
 				pools, err := c.PoolsRetired(j.ctx, j.query)
 				if len(pools) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := PoolsRetiredResult{Res: pools, Err: err}
 				ch <- res
@@ -276,12 +282,12 @@ func (c *apiClient) PoolsRetiredAll(ctx context.Context) <-chan PoolsRetiredResu
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch
@@ -320,7 +326,7 @@ func (c *apiClient) PoolsRetiring(ctx context.Context, query APIQueryParams) (pr
 func (c *apiClient) PoolsRetiringAll(ctx context.Context) <-chan PoolsRetiringResult {
 	ch := make(chan PoolsRetiringResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -331,7 +337,10 @@ func (c *apiClient) PoolsRetiringAll(ctx context.Context) <-chan PoolsRetiringRe
 			for j := range jobs {
 				pools, err := c.PoolsRetiring(j.ctx, j.query)
 				if len(pools) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := PoolsRetiringResult{Res: pools, Err: err}
 				ch <- res
@@ -346,12 +355,12 @@ func (c *apiClient) PoolsRetiringAll(ctx context.Context) <-chan PoolsRetiringRe
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch
@@ -412,7 +421,7 @@ func (c *apiClient) PoolHistory(ctx context.Context, poolID string, query APIQue
 func (c *apiClient) PoolHistoryAll(ctx context.Context, poolId string) <-chan PoolHistoryResult {
 	ch := make(chan PoolHistoryResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -423,7 +432,10 @@ func (c *apiClient) PoolHistoryAll(ctx context.Context, poolId string) <-chan Po
 			for j := range jobs {
 				pools, err := c.PoolHistory(j.ctx, poolId, j.query)
 				if len(pools) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := PoolHistoryResult{Res: pools, Err: err}
 				ch <- res
@@ -438,12 +450,12 @@ func (c *apiClient) PoolHistoryAll(ctx context.Context, poolId string) <-chan Po
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch
@@ -529,7 +541,7 @@ func (c *apiClient) PoolDelegators(ctx context.Context, poolID string, query API
 func (c *apiClient) PoolDelegatorsAll(ctx context.Context, poolId string) <-chan PoolDelegatorsResult {
 	ch := make(chan PoolDelegatorsResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -540,7 +552,10 @@ func (c *apiClient) PoolDelegatorsAll(ctx context.Context, poolId string) <-chan
 			for j := range jobs {
 				pools, err := c.PoolDelegators(j.ctx, poolId, j.query)
 				if len(pools) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := PoolDelegatorsResult{Res: pools, Err: err}
 				ch <- res
@@ -555,12 +570,12 @@ func (c *apiClient) PoolDelegatorsAll(ctx context.Context, poolId string) <-chan
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch
@@ -598,7 +613,7 @@ func (c *apiClient) PoolBlocks(ctx context.Context, poolID string, query APIQuer
 func (c *apiClient) PoolBlocksAll(ctx context.Context, poolId string) <-chan PoolBlocksResult {
 	ch := make(chan PoolBlocksResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -609,7 +624,10 @@ func (c *apiClient) PoolBlocksAll(ctx context.Context, poolId string) <-chan Poo
 			for j := range jobs {
 				pools, err := c.PoolBlocks(j.ctx, poolId, j.query)
 				if len(pools) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := PoolBlocksResult{Res: pools, Err: err}
 				ch <- res
@@ -624,12 +642,12 @@ func (c *apiClient) PoolBlocksAll(ctx context.Context, poolId string) <-chan Poo
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch
@@ -667,7 +685,7 @@ func (c *apiClient) PoolUpdates(ctx context.Context, poolID string, query APIQue
 func (c *apiClient) PoolUpdatesAll(ctx context.Context, poolId string) <-chan PoolUpdateResult {
 	ch := make(chan PoolUpdateResult, c.routines)
 	jobs := make(chan methodOptions, c.routines)
-	quit := make(chan bool, c.routines)
+	quit := make(chan bool, 1)
 
 	wg := sync.WaitGroup{}
 
@@ -678,7 +696,10 @@ func (c *apiClient) PoolUpdatesAll(ctx context.Context, poolId string) <-chan Po
 			for j := range jobs {
 				pools, err := c.PoolUpdates(j.ctx, poolId, j.query)
 				if len(pools) != j.query.Count || err != nil {
-					quit <- true
+					select {
+					case quit <- true:
+					default:
+					}
 				}
 				res := PoolUpdateResult{Res: pools, Err: err}
 				ch <- res
@@ -693,12 +714,12 @@ func (c *apiClient) PoolUpdatesAll(ctx context.Context, poolId string) <-chan Po
 			select {
 			case <-quit:
 				fetchScripts = false
-				return
 			default:
 				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
 			}
 		}
 
+		close(jobs)
 		wg.Wait()
 	}()
 	return ch

--- a/testdata/epochstakedistributionbypoolintegration.golden
+++ b/testdata/epochstakedistributionbypoolintegration.golden
@@ -1,22 +1,22 @@
 [
   {
     "stake_address": "stake1uyq0yr438xvf533765w8s62eh5cmj33sed73cypt37l2m9ch78kup",
+    "pool_id": "",
     "amount": "2473962"
   },
   {
     "stake_address": "stake1uyzrq7fqfyk3nz3z7wtcxpehf9euz6x7u739pyvc25zm8ec30p6h6",
+    "pool_id": "",
     "amount": "602852649955"
   },
   {
     "stake_address": "stake1uyyvs6u6lqfc64xz6jztw8sqlv8p4fkpwzthhcjt8hfsvdc6z649m",
+    "pool_id": "",
     "amount": "10583216396"
   },
   {
     "stake_address": "stake1uy9ynpevcnv32efnh3v73cm2ap4ys3d4dc82yxm7ccntlzcrdza5z",
+    "pool_id": "",
     "amount": "782838060"
-  },
-  {
-    "stake_address": "stake1uy9xjxmldxflvxaz2znpkmgcq8z3svuq0v7tv6y3l4kja7clta3gj",
-    "amount": "100455621428"
   }
 ]

--- a/testdata/epochstakedistributionintegration.golden
+++ b/testdata/epochstakedistributionintegration.golden
@@ -1,5 +1,10 @@
 [
   {
+    "stake_address": "stake1uyqqqj9kvqnnc4t6qt39nj5sdr5tpae906cejuyjvrhpuvssqn32g",
+    "pool_id": "pool1qqqqqdk4zhsjuxxd8jyvwncf5eucfskz0xjjj64fdmlgj735lr9",
+    "amount": "640295070"
+  },
+  {
     "stake_address": "stake1uyqqr23f3gvakvuneaxgc2009zvztuattzkuufq2qnzvw9snvmd03",
     "pool_id": "pool1myvgx4ef424e6nw2strqq7dxcepav52plyyhxrk0avaw7y098l2",
     "amount": "48205931990"
@@ -18,10 +23,5 @@
     "stake_address": "stake1uyqqx5v0f49c8rgymszw9gdgrea9yanhrk5fcg9ymgs2jnctyyj94",
     "pool_id": "pool1a2nh3ktswllhwf07fjahpdg5mpqyq7j950pyftq9765r6t4cefl",
     "amount": "59519451196"
-  },
-  {
-    "stake_address": "stake1uyqq2a22arunrft3k9ehqc7yjpxtxjmvgndae80xw89mwyge9skyp",
-    "pool_id": "pool1ell3xjtspzzz4vtsatscan6rheltf7j3hh2s8qsam2h3jvcxzm9",
-    "amount": "151262378560"
   }
 ]

--- a/testdata/ipfsresourcepinintegration.golden
+++ b/testdata/ipfsresourcepinintegration.golden
@@ -1,1 +1,1 @@
-{"ipfs_hash":"QmRFKhzSSRMRTnLf1gRdDbP9PgQxsoXD2QYEHZeBA6gLHn","state":"queued"}
+{"time_created":0,"time_pinned":0,"ipfs_hash":"QmUBzUmJn1dzMQ5ooN8yVvK6TRuTdFnxdkxZi8bQDQ3tuS","state":"queued","size":""}

--- a/testdata/ipfsresourcepinnedintegration.golden
+++ b/testdata/ipfsresourcepinnedintegration.golden
@@ -1,1 +1,1 @@
-{"time_created":1634301841660,"time_pinned":1635270021327,"ipfs_hash":"QmRFKhzSSRMRTnLf1gRdDbP9PgQxsoXD2QYEHZeBA6gLHn","state":"queued","size":"131"}
+{"time_created":1649205656806,"time_pinned":1649205657450,"ipfs_hash":"QmUBzUmJn1dzMQ5ooN8yVvK6TRuTdFnxdkxZi8bQDQ3tuS","state":"queued","size":"125"}

--- a/testdata/ipfsresourcepinnedobjectsintegration.golden
+++ b/testdata/ipfsresourcepinnedobjectsintegration.golden
@@ -1,1 +1,1 @@
-[{"time_created":1632252357454,"time_pinned":1632260783786,"ipfs_hash":"QmWWTSbjJ7MFeLjDnnibybkJiFJ11FZYxgf7Rn2A5Zj94V","state":"pinned","size":"24"},{"time_created":1634301841660,"time_pinned":1635270021327,"ipfs_hash":"QmRFKhzSSRMRTnLf1gRdDbP9PgQxsoXD2QYEHZeBA6gLHn","state":"queued","size":"131"}]
+[{"time_created":1649205656806,"time_pinned":1649205657450,"ipfs_hash":"QmUBzUmJn1dzMQ5ooN8yVvK6TRuTdFnxdkxZi8bQDQ3tuS","state":"queued","size":"125"}]

--- a/testdata/ipfsresourceremoveintegration.golden
+++ b/testdata/ipfsresourceremoveintegration.golden
@@ -1,1 +1,1 @@
-{"ipfs_hash":"QmRFKhzSSRMRTnLf1gRdDbP9PgQxsoXD2QYEHZeBA6gLHn"}
+{"name":"","ipfs_hash":"QmUBzUmJn1dzMQ5ooN8yVvK6TRuTdFnxdkxZi8bQDQ3tuS","size":""}

--- a/testdata/resourceassetsintegration.golden
+++ b/testdata/resourceassetsintegration.golden
@@ -13,7 +13,7 @@
   },
   {
     "asset": "02f68378e37af4545d027d0a9fa5581ac682897a3fc1f6d8f936ed2b4154414441",
-    "quantity": "1000000",
+    "quantity": "2000000",
     "onchain_metadata": {},
     "metadata": {}
   },

--- a/testdata/resourceinfointegration.golden
+++ b/testdata/resourceinfointegration.golden
@@ -1,4 +1,4 @@
 {
   "url": "https://blockfrost.io/",
-  "version": "0.12.2"
+  "version": "0.19.4"
 }


### PR DESCRIPTION
Each of these methods was panic'ing because of an attempt to send on a
channel that was already closed.

This fixes that, and a few subsequent issues that arose.  In particular:
 - Let the loop break, rather than returning, to ensure we wait for each
   job to finsih before closing the channel
 - Close the jobs queue so each worker finishes, and decrements the
   waitgroup
 - Make the write to the quit channel non-blocking, since the quit
   channel doesn't get drained
 - Now that the quit channel is non-blocking, we can make it size 1

This also updates several out of date golden test data