### PR TITLE
Include the output index in the TransactionUTXOs query

### DIFF
--- a/api_transactions.go
+++ b/api_transactions.go
@@ -104,11 +104,16 @@ type TransactionUTXOs struct {
 
 		// Hash of the UTXO transaction
 		TxHash string `json:"tx_hash"`
+
+		DataHash string `json:"data_hash"`
+		Collateral bool `json:"collateral"`
 	} `json:"inputs"`
 	Outputs []struct {
 		// Output address
 		Address string     `json:"address"`
 		Amount  []TxAmount `json:"amount"`
+		OutputIndex int `json:"output_index"`
+		DataHash string `json:"data_hash"`
 	} `json:"outputs"`
 }
 


### PR DESCRIPTION
Sometimes these are coming back out of order, so we can't rely on the order in the array.  Arguably we could also sort them before returning to the user, for convenience.  Happy to make that change if requested, but I figured I'd keep it minimal for now