### PR TITLE
Revert "Use correct URL piece for AssetAddresses"

### DIFF
--- a/api_assets.go
+++ b/api_assets.go
@@ -242,7 +242,7 @@ func (c *apiClient) AssetTransactions(ctx context.Context, asset string) (trs []
 
 // AssetAddresses returns list of a addresses containing a specific asset.
 func (c *apiClient) AssetAddresses(ctx context.Context, asset string) (addrs []AssetAddress, err error) {
-	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s/%s", c.server, resourceAssets, asset, resourceAssetAddresses))
+	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s/%s", c.server, resourceAssets, asset, resourceAssetHistory))
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Reverts blockfrost/blockfrost-go#60. Fixed in #61