### PR TITLE
Remove unused Retry* fields

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
 )
@@ -33,14 +32,10 @@ type APIClientOptions struct {
 
 	// Max number of routines to use for *All methods
 	MaxRoutines int
-
-	RetryWaitMin time.Duration // Minimum time to wait
-	RetryWaitMax time.Duration // Maximum time to wait
-	RetryMax     int           // Maximum number of retries
 }
 
 // NewAPICLient creates a client from APIClientOptions. If no options are provided,
-//  client with default configurations is returned.
+// client with default configurations is returned.
 func NewAPIClient(options APIClientOptions) APIClient {
 	if options.Server == "" {
 		options.Server = CardanoMainNet


### PR DESCRIPTION
These fields are exported but don't appear to be used anywhere which is misleading.  
Introduced in 740fa5406c840a901daeeb4aad09be666e3d1b7a
