### PR TITLE
feat: add governance endpoints, missing methods, and update structs f…

### DIFF
--- a/api_account.go
+++ b/api_account.go
@@ -19,6 +19,8 @@ const (
 	resourceAccountMIRHistory                  = "mirs"
 	resourceAccountAssociatedAddress           = "addresses"
 	resourceAccountAddressWithAssetsAssociated = "addresses/assets"
+	resourceAccountAddressesTotal              = "addresses/total"
+	resourceAccountTransactions                = "transactions"
 )
 
 // Account return Specific account address
@@ -53,6 +55,12 @@ type Account struct {
 
 	// Bech32 pool ID that owns the account
 	PoolID *string `json:"pool_id"`
+
+	// Bech32 DRep ID associated with the account
+	DrepId *string `json:"drep_id"`
+
+	// Registration state of an account
+	Registered bool `json:"registered"`
 }
 
 // AccountRewardsHist return Account reward history
@@ -95,6 +103,15 @@ type AccountDelegationHistory struct {
 
 	// Bech32 ID of pool being delegated to
 	PoolID string `json:"pool_id"`
+
+	// Slot of the transaction
+	TxSlot int `json:"tx_slot"`
+
+	// Block time of the transaction
+	BlockTime int `json:"block_time"`
+
+	// Block height of the transaction
+	BlockHeight int `json:"block_height"`
 }
 
 // AccountRegistrationHistory return Account registration history
@@ -106,6 +123,15 @@ type AccountRegistrationHistory struct {
 	// Action in the certificate
 	// Enum: "registered" "deregistered"
 	Action string `json:"action"`
+
+	// Slot of the transaction
+	TxSlot int `json:"tx_slot"`
+
+	// Block time of the transaction
+	BlockTime int `json:"block_time"`
+
+	// Block height of the transaction
+	BlockHeight int `json:"block_height"`
 }
 
 // AccountWithdrawalHistory return Account withdrawal history
@@ -116,6 +142,15 @@ type AccountWithdrawalHistory struct {
 
 	// Withdrawal amount in Lovelaces
 	Amount string `json:"amount"`
+
+	// Slot of the transaction
+	TxSlot int `json:"tx_slot"`
+
+	// Block time of the transaction
+	BlockTime int `json:"block_time"`
+
+	// Block height of the transaction
+	BlockHeight int `json:"block_height"`
 }
 
 // AccountMIRHistory return Account MIR history
@@ -126,6 +161,15 @@ type AccountMIRHistory struct {
 
 	// MIR amount in Lovelaces
 	Amount string `json:"amount"`
+
+	// Slot of the transaction
+	TxSlot int `json:"tx_slot"`
+
+	// Block time of the transaction
+	BlockTime int `json:"block_time"`
+
+	// Block height of the transaction
+	BlockHeight int `json:"block_height"`
 }
 
 // AccountAssociatedAddress return Account associated addresses
@@ -145,6 +189,27 @@ type AccountAssociatedAsset struct {
 
 	// The quantity of the unit
 	Quantity string `json:"quantity"`
+}
+
+type AccountAddressesTotal struct {
+	StakeAddress string `json:"stake_address"`
+	ReceivedSum  []struct {
+		Unit     string `json:"unit"`
+		Quantity string `json:"quantity"`
+	} `json:"received_sum"`
+	SentSum []struct {
+		Unit     string `json:"unit"`
+		Quantity string `json:"quantity"`
+	} `json:"sent_sum"`
+	TxCount int `json:"tx_count"`
+}
+
+type AccountTransaction struct {
+	TxHash      string `json:"tx_hash"`
+	TxIndex     int    `json:"tx_index"`
+	BlockHeight int    `json:"block_height"`
+	BlockTime   int    `json:"block_time"`
+	Address     string `json:"address"`
 }
 
 type AccountHistoryResult struct {
@@ -184,6 +249,11 @@ type AccountAssociatedAddressesAll struct {
 
 type AccountAssociatedAssetsAll struct {
 	Res []AccountAssociatedAsset
+	Err error
+}
+
+type AccountTransactionResult struct {
+	Res []AccountTransaction
 	Err error
 }
 
@@ -763,6 +833,96 @@ func (c *apiClient) AccountAssociatedAssetsAll(ctx context.Context, stakeAddress
 					}
 				}
 				res := AccountAssociatedAssetsAll{Res: as, Err: err}
+				ch <- res
+			}
+
+		}(jobs, ch, &wg)
+	}
+	go func() {
+		defer close(ch)
+		fetchNextPage := true
+		for i := 1; fetchNextPage; i++ {
+			select {
+			case <-quit:
+				fetchNextPage = false
+			default:
+				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
+			}
+		}
+
+		close(jobs)
+		wg.Wait()
+	}()
+	return ch
+}
+
+// AccountAddressesTotal returns the content of a requested Account by the specific stake account.
+// Obtain information about the total addresses.
+func (c *apiClient) AccountAddressesTotal(ctx context.Context, stakeAddress string) (aat AccountAddressesTotal, err error) {
+	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s/%s", c.server, resourceAccount, stakeAddress, resourceAccountAddressesTotal))
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl.String(), nil)
+	if err != nil {
+		return
+	}
+	res, err := c.handleRequest(req)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+	if err = json.NewDecoder(res.Body).Decode(&aat); err != nil {
+		return
+	}
+	return aat, nil
+}
+
+// AccountTransactions returns the content of a requested Account by the specific stake account.
+// Obtain information about the transactions.
+func (c *apiClient) AccountTransactions(ctx context.Context, stakeAddress string, query APIQueryParams) (at []AccountTransaction, err error) {
+	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s/%s", c.server, resourceAccount, stakeAddress, resourceAccountTransactions))
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl.String(), nil)
+	if err != nil {
+		return
+	}
+	v := req.URL.Query()
+	v = formatParams(v, query)
+	req.URL.RawQuery = v.Encode()
+	res, err := c.handleRequest(req)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+	if err = json.NewDecoder(res.Body).Decode(&at); err != nil {
+		return
+	}
+	return at, nil
+}
+
+func (c *apiClient) AccountTransactionsAll(ctx context.Context, stakeAddress string) <-chan AccountTransactionResult {
+	ch := make(chan AccountTransactionResult, c.routines)
+	jobs := make(chan methodOptions, c.routines)
+	quit := make(chan bool, 1)
+
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < c.routines; i++ {
+		wg.Add(1)
+		go func(jobs chan methodOptions, ch chan AccountTransactionResult, wg *sync.WaitGroup) {
+			defer wg.Done()
+			for j := range jobs {
+				txs, err := c.AccountTransactions(j.ctx, stakeAddress, j.query)
+				if len(txs) != j.query.Count || err != nil {
+					select {
+					case quit <- true:
+					default:
+					}
+				}
+				res := AccountTransactionResult{Res: txs, Err: err}
 				ch <- res
 			}
 

--- a/api_assets.go
+++ b/api_assets.go
@@ -116,6 +116,16 @@ type AssetByPolicyResult struct {
 	Err error
 }
 
+type AssetHistoryResult struct {
+	Res []AssetHistory
+	Err error
+}
+
+type AssetTransactionResult struct {
+	Res []AssetTransaction
+	Err error
+}
+
 type AssetAddressesAll struct {
 	Res []AssetAddress
 	Err error
@@ -213,7 +223,7 @@ func (c *apiClient) Asset(ctx context.Context, asset string) (a Asset, err error
 }
 
 // AssetHistory returns history of a specific asset.
-func (c *apiClient) AssetHistory(ctx context.Context, asset string) (hist []AssetHistory, err error) {
+func (c *apiClient) AssetHistory(ctx context.Context, asset string, query APIQueryParams) (hist []AssetHistory, err error) {
 	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s/%s", c.server, resourceAssets, asset, resourceAssetHistory))
 	if err != nil {
 		return
@@ -222,6 +232,10 @@ func (c *apiClient) AssetHistory(ctx context.Context, asset string) (hist []Asse
 	if err != nil {
 		return
 	}
+
+	v := req.URL.Query()
+	v = formatParams(v, query)
+	req.URL.RawQuery = v.Encode()
 
 	res, err := c.handleRequest(req)
 	if err != nil {
@@ -236,7 +250,7 @@ func (c *apiClient) AssetHistory(ctx context.Context, asset string) (hist []Asse
 }
 
 // AssetTransactions returns list of a specific asset transactions.
-func (c *apiClient) AssetTransactions(ctx context.Context, asset string) (trs []AssetTransaction, err error) {
+func (c *apiClient) AssetTransactions(ctx context.Context, asset string, query APIQueryParams) (trs []AssetTransaction, err error) {
 	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s/%s", c.server, resourceAssets, asset, resourceAssetTransactions))
 	if err != nil {
 		return
@@ -245,6 +259,10 @@ func (c *apiClient) AssetTransactions(ctx context.Context, asset string) (trs []
 	if err != nil {
 		return
 	}
+
+	v := req.URL.Query()
+	v = formatParams(v, query)
+	req.URL.RawQuery = v.Encode()
 
 	res, err := c.handleRequest(req)
 	if err != nil {
@@ -330,7 +348,7 @@ func (c *apiClient) AssetAddressesAll(ctx context.Context, asset string) <-chan 
 }
 
 // AssetsByPolicy returns list of assets minted under a specific policy.
-func (c *apiClient) AssetsByPolicy(ctx context.Context, policyId string) (a []AssetByPolicy, err error) {
+func (c *apiClient) AssetsByPolicy(ctx context.Context, policyId string, query APIQueryParams) (a []AssetByPolicy, err error) {
 	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s", c.server, resourcePolicyAssets, policyId))
 	if err != nil {
 		return
@@ -339,6 +357,10 @@ func (c *apiClient) AssetsByPolicy(ctx context.Context, policyId string) (a []As
 	if err != nil {
 		return
 	}
+
+	v := req.URL.Query()
+	v = formatParams(v, query)
+	req.URL.RawQuery = v.Encode()
 
 	res, err := c.handleRequest(req)
 	if err != nil {
@@ -350,4 +372,136 @@ func (c *apiClient) AssetsByPolicy(ctx context.Context, policyId string) (a []As
 		return
 	}
 	return a, nil
+}
+
+// AssetHistoryAll returns the entire history of a specific asset.
+func (c *apiClient) AssetHistoryAll(ctx context.Context, asset string) <-chan AssetHistoryResult {
+	ch := make(chan AssetHistoryResult, c.routines)
+	jobs := make(chan methodOptions, c.routines)
+	quit := make(chan bool, 1)
+
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < c.routines; i++ {
+		wg.Add(1)
+		go func(jobs chan methodOptions, ch chan AssetHistoryResult, wg *sync.WaitGroup) {
+			defer wg.Done()
+			for j := range jobs {
+				hist, err := c.AssetHistory(j.ctx, asset, j.query)
+				if len(hist) != j.query.Count || err != nil {
+					select {
+					case quit <- true:
+					default:
+					}
+				}
+				res := AssetHistoryResult{Res: hist, Err: err}
+				ch <- res
+			}
+
+		}(jobs, ch, &wg)
+	}
+	go func() {
+		defer close(ch)
+		fetchNextPage := true
+		for i := 1; fetchNextPage; i++ {
+			select {
+			case <-quit:
+				fetchNextPage = false
+			default:
+				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
+			}
+		}
+
+		close(jobs)
+		wg.Wait()
+	}()
+	return ch
+}
+
+// AssetTransactionsAll returns all transactions of a specific asset.
+func (c *apiClient) AssetTransactionsAll(ctx context.Context, asset string) <-chan AssetTransactionResult {
+	ch := make(chan AssetTransactionResult, c.routines)
+	jobs := make(chan methodOptions, c.routines)
+	quit := make(chan bool, 1)
+
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < c.routines; i++ {
+		wg.Add(1)
+		go func(jobs chan methodOptions, ch chan AssetTransactionResult, wg *sync.WaitGroup) {
+			defer wg.Done()
+			for j := range jobs {
+				trs, err := c.AssetTransactions(j.ctx, asset, j.query)
+				if len(trs) != j.query.Count || err != nil {
+					select {
+					case quit <- true:
+					default:
+					}
+				}
+				res := AssetTransactionResult{Res: trs, Err: err}
+				ch <- res
+			}
+
+		}(jobs, ch, &wg)
+	}
+	go func() {
+		defer close(ch)
+		fetchNextPage := true
+		for i := 1; fetchNextPage; i++ {
+			select {
+			case <-quit:
+				fetchNextPage = false
+			default:
+				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
+			}
+		}
+
+		close(jobs)
+		wg.Wait()
+	}()
+	return ch
+}
+
+// AssetsByPolicyAll returns all assets minted under a specific policy.
+func (c *apiClient) AssetsByPolicyAll(ctx context.Context, policyId string) <-chan AssetByPolicyResult {
+	ch := make(chan AssetByPolicyResult, c.routines)
+	jobs := make(chan methodOptions, c.routines)
+	quit := make(chan bool, 1)
+
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < c.routines; i++ {
+		wg.Add(1)
+		go func(jobs chan methodOptions, ch chan AssetByPolicyResult, wg *sync.WaitGroup) {
+			defer wg.Done()
+			for j := range jobs {
+				assets, err := c.AssetsByPolicy(j.ctx, policyId, j.query)
+				if len(assets) != j.query.Count || err != nil {
+					select {
+					case quit <- true:
+					default:
+					}
+				}
+				res := AssetByPolicyResult{Res: assets, Err: err}
+				ch <- res
+			}
+
+		}(jobs, ch, &wg)
+	}
+	go func() {
+		defer close(ch)
+		fetchNextPage := true
+		for i := 1; fetchNextPage; i++ {
+			select {
+			case <-quit:
+				fetchNextPage = false
+			default:
+				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
+			}
+		}
+
+		close(jobs)
+		wg.Wait()
+	}()
+	return ch
 }

--- a/api_assets_test.go
+++ b/api_assets_test.go
@@ -83,7 +83,7 @@ func TestResourceAssetHistoryIntegration(t *testing.T) {
 	asset := "3a9241cd79895e3a8d65261b40077d4437ce71e9d7c8c6c00e3f658e4669727374636f696e"
 	api := blockfrost.NewAPIClient(blockfrost.APIClientOptions{})
 
-	got, err := api.AssetHistory(context.TODO(), asset)
+	got, err := api.AssetHistory(context.TODO(), asset, blockfrost.APIQueryParams{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestResourceAssetTransactionIntegration(t *testing.T) {
 	asset := "3a9241cd79895e3a8d65261b40077d4437ce71e9d7c8c6c00e3f658e4669727374636f696e"
 	api := blockfrost.NewAPIClient(blockfrost.APIClientOptions{})
 
-	got, err := api.AssetTransactions(context.TODO(), asset)
+	got, err := api.AssetTransactions(context.TODO(), asset, blockfrost.APIQueryParams{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func TestResourceAssetsByPolicyIntegration(t *testing.T) {
 	policy := "3a9241cd79895e3a8d65261b40077d4437ce71e9d7c8c6c00e3f658e"
 	api := blockfrost.NewAPIClient(blockfrost.APIClientOptions{})
 
-	got, err := api.AssetsByPolicy(context.TODO(), policy)
+	got, err := api.AssetsByPolicy(context.TODO(), policy, blockfrost.APIQueryParams{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api_block.go
+++ b/api_block.go
@@ -79,6 +79,11 @@ type BlockAffectedAddressesResult struct {
 	Err error
 }
 
+type BlockTransactionResult struct {
+	Res []Transaction
+	Err error
+}
+
 // BlocksLatest Return the latest block available to the backends, also known as the
 // tip of the blockchain.
 func (c *apiClient) BlockLatest(ctx context.Context) (b Block, err error) {
@@ -180,7 +185,7 @@ func (c *apiClient) BlocksPrevious(ctx context.Context, hashorNumber string) (bl
 
 // BlocksTransactions returns slice of Transaction within the block specified
 // by a hash or block number
-func (c *apiClient) BlockTransactions(ctx context.Context, hashOrNumber string) (txs []Transaction, err error) {
+func (c *apiClient) BlockTransactions(ctx context.Context, hashOrNumber string, query APIQueryParams) (txs []Transaction, err error) {
 	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s/%s", c.server, resourceBlock, hashOrNumber, "txs"))
 	if err != nil {
 		return
@@ -189,6 +194,11 @@ func (c *apiClient) BlockTransactions(ctx context.Context, hashOrNumber string) 
 	if err != nil {
 		return
 	}
+
+	v := req.URL.Query()
+	v = formatParams(v, query)
+	req.URL.RawQuery = v.Encode()
+
 	res, err := c.handleRequest(req)
 	if err != nil {
 		return
@@ -203,7 +213,7 @@ func (c *apiClient) BlockTransactions(ctx context.Context, hashOrNumber string) 
 }
 
 // BlockLatestTransactions returns the transactions within the latest block.
-func (c *apiClient) BlockLatestTransactions(ctx context.Context) (txs []Transaction, err error) {
+func (c *apiClient) BlockLatestTransactions(ctx context.Context, query APIQueryParams) (txs []Transaction, err error) {
 	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s", c.server, resourceBlocksLatestTransactions))
 	if err != nil {
 		return
@@ -212,6 +222,10 @@ func (c *apiClient) BlockLatestTransactions(ctx context.Context) (txs []Transact
 	if err != nil {
 		return
 	}
+
+	v := req.URL.Query()
+	v = formatParams(v, query)
+	req.URL.RawQuery = v.Encode()
 
 	res, err := c.handleRequest(req)
 	if err != nil {
@@ -321,6 +335,95 @@ func (c *apiClient) BlocksAddressesAll(ctx context.Context, hashOrNumber string)
 					}
 				}
 				res := BlockAffectedAddressesResult{Res: affectedAddresses, Err: err}
+				ch <- res
+			}
+
+		}(jobs, ch, &wg)
+	}
+	go func() {
+		defer close(ch)
+		fetchNextPage := true
+		for i := 1; fetchNextPage; i++ {
+			select {
+			case <-quit:
+				fetchNextPage = false
+			default:
+				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
+			}
+		}
+
+		close(jobs)
+		wg.Wait()
+	}()
+	return ch
+}
+
+// BlockTransactionsAll returns all transactions within the block specified
+// by a hash or block number.
+func (c *apiClient) BlockTransactionsAll(ctx context.Context, hashOrNumber string) <-chan BlockTransactionResult {
+	ch := make(chan BlockTransactionResult, c.routines)
+	jobs := make(chan methodOptions, c.routines)
+	quit := make(chan bool, 1)
+
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < c.routines; i++ {
+		wg.Add(1)
+		go func(jobs chan methodOptions, ch chan BlockTransactionResult, wg *sync.WaitGroup) {
+			defer wg.Done()
+			for j := range jobs {
+				txs, err := c.BlockTransactions(j.ctx, hashOrNumber, j.query)
+				if len(txs) != j.query.Count || err != nil {
+					select {
+					case quit <- true:
+					default:
+					}
+				}
+				res := BlockTransactionResult{Res: txs, Err: err}
+				ch <- res
+			}
+
+		}(jobs, ch, &wg)
+	}
+	go func() {
+		defer close(ch)
+		fetchNextPage := true
+		for i := 1; fetchNextPage; i++ {
+			select {
+			case <-quit:
+				fetchNextPage = false
+			default:
+				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
+			}
+		}
+
+		close(jobs)
+		wg.Wait()
+	}()
+	return ch
+}
+
+// BlockLatestTransactionsAll returns all transactions within the latest block.
+func (c *apiClient) BlockLatestTransactionsAll(ctx context.Context) <-chan BlockTransactionResult {
+	ch := make(chan BlockTransactionResult, c.routines)
+	jobs := make(chan methodOptions, c.routines)
+	quit := make(chan bool, 1)
+
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < c.routines; i++ {
+		wg.Add(1)
+		go func(jobs chan methodOptions, ch chan BlockTransactionResult, wg *sync.WaitGroup) {
+			defer wg.Done()
+			for j := range jobs {
+				txs, err := c.BlockLatestTransactions(j.ctx, j.query)
+				if len(txs) != j.query.Count || err != nil {
+					select {
+					case quit <- true:
+					default:
+					}
+				}
+				res := BlockTransactionResult{Res: txs, Err: err}
 				ch <- res
 			}
 

--- a/api_block_test.go
+++ b/api_block_test.go
@@ -65,7 +65,7 @@ func TestBlockLatestTransactionsIntegration(t *testing.T) {
 	api := blockfrost.NewAPIClient(
 		blockfrost.APIClientOptions{},
 	)
-	got, err := api.BlockLatestTransactions(context.TODO())
+	got, err := api.BlockLatestTransactions(context.TODO(), blockfrost.APIQueryParams{})
 	testErrorHelper(t, err)
 	nullGot := []blockfrost.Transaction{}
 	if reflect.DeepEqual(got, nullGot) {
@@ -78,7 +78,7 @@ func TestBlockTransactions(t *testing.T) {
 	api := blockfrost.NewAPIClient(
 		blockfrost.APIClientOptions{},
 	)
-	got, err := api.BlockTransactions(context.TODO(), block)
+	got, err := api.BlockTransactions(context.TODO(), block, blockfrost.APIQueryParams{})
 	testErrorHelper(t, err)
 	nullGot := []blockfrost.Transaction{}
 	if reflect.DeepEqual(got, nullGot) {

--- a/api_epochs.go
+++ b/api_epochs.go
@@ -160,6 +160,32 @@ type EpochParameters struct {
 
 	// Cost per UTxO word for Alonzo. Cost per UTxO byte for Babbage and later.
 	CoinsPerUTxOSize *string `json:"coins_per_utxo_size"`
+
+	// Conway era governance parameters
+	CostModelsRaw              interface{} `json:"cost_models_raw"`
+	PvtMotionNoConfidence      *float64    `json:"pvt_motion_no_confidence"`
+	PvtCommitteeNormal         *float64    `json:"pvt_committee_normal"`
+	PvtCommitteeNoConfidence   *float64    `json:"pvt_committee_no_confidence"`
+	PvtHardForkInitiation      *float64    `json:"pvt_hard_fork_initiation"`
+	PvtPPSecurityGroup         *float64    `json:"pvt_p_p_security_group"`
+	PvtppSecurityGroup         *float64    `json:"pvtpp_security_group"`
+	DvtMotionNoConfidence      *float64    `json:"dvt_motion_no_confidence"`
+	DvtCommitteeNormal         *float64    `json:"dvt_committee_normal"`
+	DvtCommitteeNoConfidence   *float64    `json:"dvt_committee_no_confidence"`
+	DvtUpdateToConstitution    *float64    `json:"dvt_update_to_constitution"`
+	DvtHardForkInitiation      *float64    `json:"dvt_hard_fork_initiation"`
+	DvtPPNetworkGroup          *float64    `json:"dvt_p_p_network_group"`
+	DvtPPEconomicGroup         *float64    `json:"dvt_p_p_economic_group"`
+	DvtPPTechnicalGroup        *float64    `json:"dvt_p_p_technical_group"`
+	DvtPPGovGroup              *float64    `json:"dvt_p_p_gov_group"`
+	DvtTreasuryWithdrawal      *float64    `json:"dvt_treasury_withdrawal"`
+	CommitteeMinSize           *string     `json:"committee_min_size"`
+	CommitteeMaxTermLength     *string     `json:"committee_max_term_length"`
+	GovActionLifetime          *string     `json:"gov_action_lifetime"`
+	GovActionDeposit           *string     `json:"gov_action_deposit"`
+	DrepDeposit                *string     `json:"drep_deposit"`
+	DrepActivity               *string     `json:"drep_activity"`
+	MinFeeRefScriptCostPerByte *float64    `json:"min_fee_ref_script_cost_per_byte"`
 }
 
 type EpochResult struct {

--- a/api_governance.go
+++ b/api_governance.go
@@ -1,0 +1,765 @@
+package blockfrost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+)
+
+const (
+	resourceGovernanceDreps     = "governance/dreps"
+	resourceGovernanceProposals = "governance/proposals"
+	resourceDrepDelegators      = "delegators"
+	resourceDrepMetadata        = "metadata"
+	resourceDrepUpdates         = "updates"
+	resourceDrepVotes           = "votes"
+	resourceProposalParameters  = "parameters"
+	resourceProposalWithdrawals = "withdrawals"
+	resourceProposalVotes       = "votes"
+	resourceProposalMetadata    = "metadata"
+)
+
+type Drep struct {
+	DrepID string `json:"drep_id"`
+	Hex    string `json:"hex"`
+}
+
+type DrepDetails struct {
+	DrepID          string `json:"drep_id"`
+	Hex             string `json:"hex"`
+	Amount          string `json:"amount"`
+	Active          bool   `json:"active"`
+	ActiveEpoch     *int   `json:"active_epoch"`
+	HasScript       bool   `json:"has_script"`
+	Retired         bool   `json:"retired"`
+	Expired         bool   `json:"expired"`
+	LastActiveEpoch *int   `json:"last_active_epoch"`
+}
+
+type DrepMetadata struct {
+	DrepID       string      `json:"drep_id"`
+	Hex          string      `json:"hex"`
+	URL          string      `json:"url"`
+	Hash         string      `json:"hash"`
+	JSONMetadata interface{} `json:"json_metadata"`
+	Bytes        *string     `json:"bytes"`
+}
+
+type DrepDelegator struct {
+	Address string `json:"address"`
+	Amount  string `json:"amount"`
+}
+
+type DrepUpdate struct {
+	TxHash    string `json:"tx_hash"`
+	CertIndex int    `json:"cert_index"`
+	Action    string `json:"action"`
+}
+
+type DrepVote struct {
+	TxHash            string `json:"tx_hash"`
+	CertIndex         int    `json:"cert_index"`
+	ProposalTxHash    string `json:"proposal_tx_hash"`
+	ProposalCertIndex int    `json:"proposal_cert_index"`
+	ProposalID        string `json:"proposal_id"`
+	Vote              string `json:"vote"`
+}
+
+type Proposal struct {
+	TxHash         string `json:"tx_hash"`
+	CertIndex      int    `json:"cert_index"`
+	GovernanceType string `json:"governance_type"`
+	ID             string `json:"id"`
+}
+
+type ProposalDetails struct {
+	TxHash                string      `json:"tx_hash"`
+	CertIndex             int         `json:"cert_index"`
+	GovernanceType        string      `json:"governance_type"`
+	ID                    string      `json:"id"`
+	Deposit               string      `json:"deposit"`
+	ReturnAddress         string      `json:"return_address"`
+	GovernanceDescription interface{} `json:"governance_description"`
+	RatifiedEpoch         *int        `json:"ratified_epoch"`
+	EnactedEpoch          *int        `json:"enacted_epoch"`
+	DroppedEpoch          *int        `json:"dropped_epoch"`
+	ExpiredEpoch          *int        `json:"expired_epoch"`
+	Expiration            int         `json:"expiration"`
+}
+
+type ProposalParameters struct {
+	TxHash     string      `json:"tx_hash"`
+	CertIndex  int         `json:"cert_index"`
+	ID         string      `json:"id"`
+	Parameters interface{} `json:"parameters"`
+}
+
+type ProposalWithdrawal struct {
+	StakeAddress string `json:"stake_address"`
+	Amount       string `json:"amount"`
+}
+
+type ProposalVote struct {
+	TxHash    string `json:"tx_hash"`
+	CertIndex int    `json:"cert_index"`
+	Voter     string `json:"voter"`
+	VoterRole string `json:"voter_role"`
+	Vote      string `json:"vote"`
+}
+
+type ProposalMetadata struct {
+	TxHash       string      `json:"tx_hash"`
+	CertIndex    int         `json:"cert_index"`
+	ID           string      `json:"id"`
+	URL          string      `json:"url"`
+	Hash         string      `json:"hash"`
+	JSONMetadata interface{} `json:"json_metadata"`
+	Bytes        string      `json:"bytes"`
+}
+
+type DrepResult struct {
+	Res []Drep
+	Err error
+}
+
+type DrepDelegatorResult struct {
+	Res []DrepDelegator
+	Err error
+}
+
+type DrepUpdateResult struct {
+	Res []DrepUpdate
+	Err error
+}
+
+type DrepVoteResult struct {
+	Res []DrepVote
+	Err error
+}
+
+type ProposalResult struct {
+	Res []Proposal
+	Err error
+}
+
+type ProposalWithdrawalResult struct {
+	Res []ProposalWithdrawal
+	Err error
+}
+
+type ProposalVoteResult struct {
+	Res []ProposalVote
+	Err error
+}
+
+// Dreps returns the List of registered DReps.
+func (c *apiClient) Dreps(ctx context.Context, query APIQueryParams) (ds []Drep, err error) {
+	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s", c.server, resourceGovernanceDreps))
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl.String(), nil)
+	if err != nil {
+		return
+	}
+
+	v := req.URL.Query()
+	v = formatParams(v, query)
+	req.URL.RawQuery = v.Encode()
+
+	res, err := c.handleRequest(req)
+	if err != nil {
+		return
+	}
+
+	defer res.Body.Close()
+
+	if err = json.NewDecoder(res.Body).Decode(&ds); err != nil {
+		return
+	}
+	return ds, nil
+}
+
+func (c *apiClient) DrepsAll(ctx context.Context) <-chan DrepResult {
+	ch := make(chan DrepResult, c.routines)
+	jobs := make(chan methodOptions, c.routines)
+	quit := make(chan bool, 1)
+
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < c.routines; i++ {
+		wg.Add(1)
+		go func(jobs chan methodOptions, ch chan DrepResult, wg *sync.WaitGroup) {
+			defer wg.Done()
+			for j := range jobs {
+				dreps, err := c.Dreps(j.ctx, j.query)
+				if len(dreps) != j.query.Count || err != nil {
+					select {
+					case quit <- true:
+					default:
+					}
+				}
+				res := DrepResult{Res: dreps, Err: err}
+				ch <- res
+			}
+
+		}(jobs, ch, &wg)
+	}
+	go func() {
+		defer close(ch)
+		fetchNextPage := true
+		for i := 1; fetchNextPage; i++ {
+			select {
+			case <-quit:
+				fetchNextPage = false
+			default:
+				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
+			}
+		}
+
+		close(jobs)
+		wg.Wait()
+	}()
+	return ch
+}
+
+// DrepDetails returns the details of a specific DRep.
+func (c *apiClient) DrepDetails(ctx context.Context, drepId string) (dd DrepDetails, err error) {
+	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s", c.server, resourceGovernanceDreps, drepId))
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl.String(), nil)
+	if err != nil {
+		return
+	}
+
+	res, err := c.handleRequest(req)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+	if err = json.NewDecoder(res.Body).Decode(&dd); err != nil {
+		return
+	}
+	return dd, nil
+}
+
+// DrepMetadata returns the metadata of a specific DRep.
+func (c *apiClient) DrepMetadata(ctx context.Context, drepId string) (dm DrepMetadata, err error) {
+	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s/%s", c.server, resourceGovernanceDreps, drepId, resourceDrepMetadata))
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl.String(), nil)
+	if err != nil {
+		return
+	}
+
+	res, err := c.handleRequest(req)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+	if err = json.NewDecoder(res.Body).Decode(&dm); err != nil {
+		return
+	}
+	return dm, nil
+}
+
+// DrepDelegators returns the list of delegators for a specific DRep.
+func (c *apiClient) DrepDelegators(ctx context.Context, drepId string, query APIQueryParams) (dd []DrepDelegator, err error) {
+	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s/%s", c.server, resourceGovernanceDreps, drepId, resourceDrepDelegators))
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl.String(), nil)
+	if err != nil {
+		return
+	}
+	v := req.URL.Query()
+	v = formatParams(v, query)
+	req.URL.RawQuery = v.Encode()
+
+	res, err := c.handleRequest(req)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+
+	if err = json.NewDecoder(res.Body).Decode(&dd); err != nil {
+		return
+	}
+	return dd, nil
+}
+
+func (c *apiClient) DrepDelegatorsAll(ctx context.Context, drepId string) <-chan DrepDelegatorResult {
+	ch := make(chan DrepDelegatorResult, c.routines)
+	jobs := make(chan methodOptions, c.routines)
+	quit := make(chan bool, 1)
+
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < c.routines; i++ {
+		wg.Add(1)
+		go func(jobs chan methodOptions, ch chan DrepDelegatorResult, wg *sync.WaitGroup) {
+			defer wg.Done()
+			for j := range jobs {
+				delegators, err := c.DrepDelegators(j.ctx, drepId, j.query)
+				if len(delegators) != j.query.Count || err != nil {
+					select {
+					case quit <- true:
+					default:
+					}
+				}
+				res := DrepDelegatorResult{Res: delegators, Err: err}
+				ch <- res
+			}
+
+		}(jobs, ch, &wg)
+	}
+	go func() {
+		defer close(ch)
+		fetchNextPage := true
+		for i := 1; fetchNextPage; i++ {
+			select {
+			case <-quit:
+				fetchNextPage = false
+			default:
+				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
+			}
+		}
+
+		close(jobs)
+		wg.Wait()
+	}()
+	return ch
+}
+
+// DrepUpdates returns the list of updates for a specific DRep.
+func (c *apiClient) DrepUpdates(ctx context.Context, drepId string, query APIQueryParams) (du []DrepUpdate, err error) {
+	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s/%s", c.server, resourceGovernanceDreps, drepId, resourceDrepUpdates))
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl.String(), nil)
+	if err != nil {
+		return
+	}
+	v := req.URL.Query()
+	v = formatParams(v, query)
+	req.URL.RawQuery = v.Encode()
+
+	res, err := c.handleRequest(req)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+
+	if err = json.NewDecoder(res.Body).Decode(&du); err != nil {
+		return
+	}
+	return du, nil
+}
+
+func (c *apiClient) DrepUpdatesAll(ctx context.Context, drepId string) <-chan DrepUpdateResult {
+	ch := make(chan DrepUpdateResult, c.routines)
+	jobs := make(chan methodOptions, c.routines)
+	quit := make(chan bool, 1)
+
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < c.routines; i++ {
+		wg.Add(1)
+		go func(jobs chan methodOptions, ch chan DrepUpdateResult, wg *sync.WaitGroup) {
+			defer wg.Done()
+			for j := range jobs {
+				updates, err := c.DrepUpdates(j.ctx, drepId, j.query)
+				if len(updates) != j.query.Count || err != nil {
+					select {
+					case quit <- true:
+					default:
+					}
+				}
+				res := DrepUpdateResult{Res: updates, Err: err}
+				ch <- res
+			}
+
+		}(jobs, ch, &wg)
+	}
+	go func() {
+		defer close(ch)
+		fetchNextPage := true
+		for i := 1; fetchNextPage; i++ {
+			select {
+			case <-quit:
+				fetchNextPage = false
+			default:
+				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
+			}
+		}
+
+		close(jobs)
+		wg.Wait()
+	}()
+	return ch
+}
+
+// DrepVotes returns the list of votes for a specific DRep.
+func (c *apiClient) DrepVotes(ctx context.Context, drepId string, query APIQueryParams) (dv []DrepVote, err error) {
+	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s/%s", c.server, resourceGovernanceDreps, drepId, resourceDrepVotes))
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl.String(), nil)
+	if err != nil {
+		return
+	}
+	v := req.URL.Query()
+	v = formatParams(v, query)
+	req.URL.RawQuery = v.Encode()
+
+	res, err := c.handleRequest(req)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+
+	if err = json.NewDecoder(res.Body).Decode(&dv); err != nil {
+		return
+	}
+	return dv, nil
+}
+
+func (c *apiClient) DrepVotesAll(ctx context.Context, drepId string) <-chan DrepVoteResult {
+	ch := make(chan DrepVoteResult, c.routines)
+	jobs := make(chan methodOptions, c.routines)
+	quit := make(chan bool, 1)
+
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < c.routines; i++ {
+		wg.Add(1)
+		go func(jobs chan methodOptions, ch chan DrepVoteResult, wg *sync.WaitGroup) {
+			defer wg.Done()
+			for j := range jobs {
+				votes, err := c.DrepVotes(j.ctx, drepId, j.query)
+				if len(votes) != j.query.Count || err != nil {
+					select {
+					case quit <- true:
+					default:
+					}
+				}
+				res := DrepVoteResult{Res: votes, Err: err}
+				ch <- res
+			}
+
+		}(jobs, ch, &wg)
+	}
+	go func() {
+		defer close(ch)
+		fetchNextPage := true
+		for i := 1; fetchNextPage; i++ {
+			select {
+			case <-quit:
+				fetchNextPage = false
+			default:
+				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
+			}
+		}
+
+		close(jobs)
+		wg.Wait()
+	}()
+	return ch
+}
+
+// Proposals returns the List of governance proposals.
+func (c *apiClient) Proposals(ctx context.Context, query APIQueryParams) (ps []Proposal, err error) {
+	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s", c.server, resourceGovernanceProposals))
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl.String(), nil)
+	if err != nil {
+		return
+	}
+
+	v := req.URL.Query()
+	v = formatParams(v, query)
+	req.URL.RawQuery = v.Encode()
+
+	res, err := c.handleRequest(req)
+	if err != nil {
+		return
+	}
+
+	defer res.Body.Close()
+
+	if err = json.NewDecoder(res.Body).Decode(&ps); err != nil {
+		return
+	}
+	return ps, nil
+}
+
+func (c *apiClient) ProposalsAll(ctx context.Context) <-chan ProposalResult {
+	ch := make(chan ProposalResult, c.routines)
+	jobs := make(chan methodOptions, c.routines)
+	quit := make(chan bool, 1)
+
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < c.routines; i++ {
+		wg.Add(1)
+		go func(jobs chan methodOptions, ch chan ProposalResult, wg *sync.WaitGroup) {
+			defer wg.Done()
+			for j := range jobs {
+				proposals, err := c.Proposals(j.ctx, j.query)
+				if len(proposals) != j.query.Count || err != nil {
+					select {
+					case quit <- true:
+					default:
+					}
+				}
+				res := ProposalResult{Res: proposals, Err: err}
+				ch <- res
+			}
+
+		}(jobs, ch, &wg)
+	}
+	go func() {
+		defer close(ch)
+		fetchNextPage := true
+		for i := 1; fetchNextPage; i++ {
+			select {
+			case <-quit:
+				fetchNextPage = false
+			default:
+				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
+			}
+		}
+
+		close(jobs)
+		wg.Wait()
+	}()
+	return ch
+}
+
+// Proposal returns the details of a specific governance proposal.
+func (c *apiClient) Proposal(ctx context.Context, txHash string, certIndex int) (pd ProposalDetails, err error) {
+	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s/%d", c.server, resourceGovernanceProposals, txHash, certIndex))
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl.String(), nil)
+	if err != nil {
+		return
+	}
+
+	res, err := c.handleRequest(req)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+	if err = json.NewDecoder(res.Body).Decode(&pd); err != nil {
+		return
+	}
+	return pd, nil
+}
+
+// ProposalParameters returns the parameters of a specific governance proposal.
+func (c *apiClient) ProposalParameters(ctx context.Context, txHash string, certIndex int) (pp ProposalParameters, err error) {
+	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s/%d/%s", c.server, resourceGovernanceProposals, txHash, certIndex, resourceProposalParameters))
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl.String(), nil)
+	if err != nil {
+		return
+	}
+
+	res, err := c.handleRequest(req)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+	if err = json.NewDecoder(res.Body).Decode(&pp); err != nil {
+		return
+	}
+	return pp, nil
+}
+
+// ProposalMetadata returns the metadata of a specific governance proposal.
+func (c *apiClient) ProposalMetadata(ctx context.Context, txHash string, certIndex int) (pm ProposalMetadata, err error) {
+	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s/%d/%s", c.server, resourceGovernanceProposals, txHash, certIndex, resourceProposalMetadata))
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl.String(), nil)
+	if err != nil {
+		return
+	}
+
+	res, err := c.handleRequest(req)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+	if err = json.NewDecoder(res.Body).Decode(&pm); err != nil {
+		return
+	}
+	return pm, nil
+}
+
+// ProposalWithdrawals returns the withdrawals of a specific governance proposal.
+func (c *apiClient) ProposalWithdrawals(ctx context.Context, txHash string, certIndex int, query APIQueryParams) (pw []ProposalWithdrawal, err error) {
+	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s/%d/%s", c.server, resourceGovernanceProposals, txHash, certIndex, resourceProposalWithdrawals))
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl.String(), nil)
+	if err != nil {
+		return
+	}
+	v := req.URL.Query()
+	v = formatParams(v, query)
+	req.URL.RawQuery = v.Encode()
+
+	res, err := c.handleRequest(req)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+
+	if err = json.NewDecoder(res.Body).Decode(&pw); err != nil {
+		return
+	}
+	return pw, nil
+}
+
+func (c *apiClient) ProposalWithdrawalsAll(ctx context.Context, txHash string, certIndex int) <-chan ProposalWithdrawalResult {
+	ch := make(chan ProposalWithdrawalResult, c.routines)
+	jobs := make(chan methodOptions, c.routines)
+	quit := make(chan bool, 1)
+
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < c.routines; i++ {
+		wg.Add(1)
+		go func(jobs chan methodOptions, ch chan ProposalWithdrawalResult, wg *sync.WaitGroup) {
+			defer wg.Done()
+			for j := range jobs {
+				withdrawals, err := c.ProposalWithdrawals(j.ctx, txHash, certIndex, j.query)
+				if len(withdrawals) != j.query.Count || err != nil {
+					select {
+					case quit <- true:
+					default:
+					}
+				}
+				res := ProposalWithdrawalResult{Res: withdrawals, Err: err}
+				ch <- res
+			}
+
+		}(jobs, ch, &wg)
+	}
+	go func() {
+		defer close(ch)
+		fetchNextPage := true
+		for i := 1; fetchNextPage; i++ {
+			select {
+			case <-quit:
+				fetchNextPage = false
+			default:
+				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
+			}
+		}
+
+		close(jobs)
+		wg.Wait()
+	}()
+	return ch
+}
+
+// ProposalVotes returns the votes of a specific governance proposal.
+func (c *apiClient) ProposalVotes(ctx context.Context, txHash string, certIndex int, query APIQueryParams) (pv []ProposalVote, err error) {
+	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s/%d/%s", c.server, resourceGovernanceProposals, txHash, certIndex, resourceProposalVotes))
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl.String(), nil)
+	if err != nil {
+		return
+	}
+	v := req.URL.Query()
+	v = formatParams(v, query)
+	req.URL.RawQuery = v.Encode()
+
+	res, err := c.handleRequest(req)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+
+	if err = json.NewDecoder(res.Body).Decode(&pv); err != nil {
+		return
+	}
+	return pv, nil
+}
+
+func (c *apiClient) ProposalVotesAll(ctx context.Context, txHash string, certIndex int) <-chan ProposalVoteResult {
+	ch := make(chan ProposalVoteResult, c.routines)
+	jobs := make(chan methodOptions, c.routines)
+	quit := make(chan bool, 1)
+
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < c.routines; i++ {
+		wg.Add(1)
+		go func(jobs chan methodOptions, ch chan ProposalVoteResult, wg *sync.WaitGroup) {
+			defer wg.Done()
+			for j := range jobs {
+				votes, err := c.ProposalVotes(j.ctx, txHash, certIndex, j.query)
+				if len(votes) != j.query.Count || err != nil {
+					select {
+					case quit <- true:
+					default:
+					}
+				}
+				res := ProposalVoteResult{Res: votes, Err: err}
+				ch <- res
+			}
+
+		}(jobs, ch, &wg)
+	}
+	go func() {
+		defer close(ch)
+		fetchNextPage := true
+		for i := 1; fetchNextPage; i++ {
+			select {
+			case <-quit:
+				fetchNextPage = false
+			default:
+				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
+			}
+		}
+
+		close(jobs)
+		wg.Wait()
+	}()
+	return ch
+}

--- a/api_network.go
+++ b/api_network.go
@@ -9,7 +9,8 @@ import (
 )
 
 const (
-	resourceNetwork = "network"
+	resourceNetwork     = "network"
+	resourceNetworkEras = "network/eras"
 )
 
 // NetworkSupply contains information on network supply
@@ -54,4 +55,49 @@ func (c *apiClient) Network(ctx context.Context) (ni NetworkInfo, err error) {
 	}
 
 	return ni, nil
+}
+
+// NetworkEraTime contains era start/end time information
+type NetworkEraTime struct {
+	Time  int `json:"time"`
+	Slot  int `json:"slot"`
+	Epoch int `json:"epoch"`
+}
+
+// NetworkEraParameters contains era parameters
+type NetworkEraParameters struct {
+	EpochLength int `json:"epoch_length"`
+	SlotLength  int `json:"slot_length"`
+	SafeZone    int `json:"safe_zone"`
+}
+
+// NetworkEra contains information on a network era
+type NetworkEra struct {
+	Start      NetworkEraTime       `json:"start"`
+	End        NetworkEraTime       `json:"end"`
+	Parameters NetworkEraParameters `json:"parameters"`
+}
+
+// NetworkEras returns network era information.
+func (c *apiClient) NetworkEras(ctx context.Context) (ne []NetworkEra, err error) {
+	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s", c.server, resourceNetworkEras))
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl.String(), nil)
+	if err != nil {
+		return
+	}
+
+	res, err := c.handleRequest(req)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+	if err = json.NewDecoder(res.Body).Decode(&ne); err != nil {
+		return
+	}
+
+	return ne, nil
 }

--- a/api_pool.go
+++ b/api_pool.go
@@ -19,6 +19,7 @@ const (
 	resourcePoolDelegator = "delegators"
 	resourcePoolBlocks    = "blocks"
 	resourcePoolUpdate    = "updates"
+	resourcePoolExtended  = "pools/extended"
 )
 
 // List of stake pools
@@ -55,8 +56,19 @@ type Pool struct {
 	FixedCost      string   `json:"fixed_cost"`
 	RewardAccount  string   `json:"reward_account"`
 	Owners         []string `json:"owners"`
-	Registration   []string `json:"registration"`
-	Retirement     []string `json:"retirement"`
+	Registration   []string    `json:"registration"`
+	Retirement     []string    `json:"retirement"`
+	CalidusKey     *CalidusKey `json:"calidus_key"`
+}
+
+type CalidusKey struct {
+	ID          string `json:"id"`
+	PubKey      string `json:"pub_key"`
+	Nonce       int    `json:"nonce"`
+	TxHash      string `json:"tx_hash"`
+	BlockHeight int    `json:"block_height"`
+	BlockTime   int    `json:"block_time"`
+	Epoch       int    `json:"epoch"`
 }
 
 // PoolHistory return Stake pool history
@@ -81,7 +93,13 @@ type PoolMetadata struct {
 	Ticker      *string `json:"ticker"`
 	Name        *string `json:"name"`
 	Description *string `json:"description"`
-	Homepage    *string `json:"homepage"`
+	Homepage    *string        `json:"homepage"`
+	Error       *MetadataError `json:"error"`
+}
+
+type MetadataError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
 }
 
 // PoolRelay return Stake pool relays
@@ -145,6 +163,34 @@ type PoolBlocksResult struct {
 
 type PoolUpdateResult struct {
 	Res []PoolUpdate
+	Err error
+}
+
+type PoolExtendedMetadata struct {
+	URL         *string        `json:"url"`
+	Hash        *string        `json:"hash"`
+	Ticker      *string        `json:"ticker"`
+	Name        *string        `json:"name"`
+	Description *string        `json:"description"`
+	Homepage    *string        `json:"homepage"`
+	Error       *MetadataError `json:"error"`
+}
+
+type PoolExtended struct {
+	PoolID         string                `json:"pool_id"`
+	Hex            string                `json:"hex"`
+	ActiveStake    string                `json:"active_stake"`
+	LiveStake      string                `json:"live_stake"`
+	LiveSaturation float64               `json:"live_saturation"`
+	BlocksMinted   int                   `json:"blocks_minted"`
+	MarginCost     float64               `json:"margin_cost"`
+	FixedCost      string                `json:"fixed_cost"`
+	DeclaredPledge string                `json:"declared_pledge"`
+	Metadata       *PoolExtendedMetadata `json:"metadata"`
+}
+
+type PoolsExtendedResult struct {
+	Res []PoolExtended
 	Err error
 }
 
@@ -702,6 +748,72 @@ func (c *apiClient) PoolUpdatesAll(ctx context.Context, poolId string) <-chan Po
 					}
 				}
 				res := PoolUpdateResult{Res: pools, Err: err}
+				ch <- res
+			}
+
+		}(jobs, ch, &wg)
+	}
+	go func() {
+		defer close(ch)
+		fetchNextPage := true
+		for i := 1; fetchNextPage; i++ {
+			select {
+			case <-quit:
+				fetchNextPage = false
+			default:
+				jobs <- methodOptions{ctx: ctx, query: APIQueryParams{Count: 100, Page: i}}
+			}
+		}
+
+		close(jobs)
+		wg.Wait()
+	}()
+	return ch
+}
+
+func (c *apiClient) PoolsExtended(ctx context.Context, query APIQueryParams) (pe []PoolExtended, err error) {
+	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s", c.server, resourcePoolExtended))
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl.String(), nil)
+	if err != nil {
+		return
+	}
+	v := req.URL.Query()
+	v = formatParams(v, query)
+	req.URL.RawQuery = v.Encode()
+	res, err := c.handleRequest(req)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+	if err = json.NewDecoder(res.Body).Decode(&pe); err != nil {
+		return
+	}
+	return pe, nil
+}
+
+func (c *apiClient) PoolsExtendedAll(ctx context.Context) <-chan PoolsExtendedResult {
+	ch := make(chan PoolsExtendedResult, c.routines)
+	jobs := make(chan methodOptions, c.routines)
+	quit := make(chan bool, 1)
+
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < c.routines; i++ {
+		wg.Add(1)
+		go func(jobs chan methodOptions, ch chan PoolsExtendedResult, wg *sync.WaitGroup) {
+			defer wg.Done()
+			for j := range jobs {
+				pools, err := c.PoolsExtended(j.ctx, j.query)
+				if len(pools) != j.query.Count || err != nil {
+					select {
+					case quit <- true:
+					default:
+					}
+				}
+				res := PoolsExtendedResult{Res: pools, Err: err}
 				ch <- res
 			}
 

--- a/api_script.go
+++ b/api_script.go
@@ -10,12 +10,12 @@ import (
 )
 
 const (
-	resourceScripts   = "scripts"
-	resourceRedeemers = "redeemers"
-	// resourceScriptsJson = "json"
-	// resourceScriptsCbor = "cbor"
-	// resourceDatum       = "datum"
-	// resourceDatumCbor   = "cbor"
+	resourceScripts         = "scripts"
+	resourceRedeemers       = "redeemers"
+	resourceScriptJSON      = "json"
+	resourceScriptCBOR      = "cbor"
+	resourceScriptDatum     = "scripts/datum"
+	resourceScriptDatumCBOR = "cbor"
 )
 
 // Script contains information about a script
@@ -67,6 +67,22 @@ type ScriptAllResult struct {
 type ScriptRedeemerResult struct {
 	Res []ScriptRedeemer
 	Err error
+}
+
+type ScriptJSON struct {
+	JSON interface{} `json:"json"`
+}
+
+type ScriptCBOR struct {
+	CBOR *string `json:"cbor"`
+}
+
+type ScriptDatum struct {
+	JSONValue interface{} `json:"json_value"`
+}
+
+type ScriptDatumCBOR struct {
+	CBOR string `json:"cbor"`
 }
 
 // Scripts returns a paginated list of scripts.
@@ -228,4 +244,84 @@ func (c *apiClient) ScriptRedeemersAll(ctx context.Context, address string) <-ch
 		wg.Wait()
 	}()
 	return ch
+}
+
+func (c *apiClient) ScriptJSON(ctx context.Context, scriptHash string) (sj ScriptJSON, err error) {
+	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s/%s", c.server, resourceScripts, scriptHash, resourceScriptJSON))
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl.String(), nil)
+	if err != nil {
+		return
+	}
+	res, err := c.handleRequest(req)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+	if err = json.NewDecoder(res.Body).Decode(&sj); err != nil {
+		return
+	}
+	return sj, nil
+}
+
+func (c *apiClient) ScriptCBOR(ctx context.Context, scriptHash string) (sc ScriptCBOR, err error) {
+	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s/%s", c.server, resourceScripts, scriptHash, resourceScriptCBOR))
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl.String(), nil)
+	if err != nil {
+		return
+	}
+	res, err := c.handleRequest(req)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+	if err = json.NewDecoder(res.Body).Decode(&sc); err != nil {
+		return
+	}
+	return sc, nil
+}
+
+func (c *apiClient) ScriptDatum(ctx context.Context, datumHash string) (sd ScriptDatum, err error) {
+	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s", c.server, resourceScriptDatum, datumHash))
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl.String(), nil)
+	if err != nil {
+		return
+	}
+	res, err := c.handleRequest(req)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+	if err = json.NewDecoder(res.Body).Decode(&sd); err != nil {
+		return
+	}
+	return sd, nil
+}
+
+func (c *apiClient) ScriptDatumCBOR(ctx context.Context, datumHash string) (sdc ScriptDatumCBOR, err error) {
+	requestUrl, err := url.Parse(fmt.Sprintf("%s/%s/%s/%s", c.server, resourceScriptDatum, datumHash, resourceScriptDatumCBOR))
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl.String(), nil)
+	if err != nil {
+		return
+	}
+	res, err := c.handleRequest(req)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+	if err = json.NewDecoder(res.Body).Decode(&sdc); err != nil {
+		return
+	}
+	return sdc, nil
 }

--- a/api_transactions.go
+++ b/api_transactions.go
@@ -97,6 +97,8 @@ type TransactionContent struct {
 
 	// Count of the withdrawals within the transaction
 	WithdrawalCount int `json:"withdrawal_count"`
+
+	TreasuryDonation string `json:"treasury_donation"`
 }
 
 type TransactionCBOR struct {
@@ -130,6 +132,7 @@ type TransactionOutput struct {
 	DataHash            *string    `json:"data_hash"`
 	InlineDatum         *string    `json:"inline_datum"`
 	ReferenceScriptHash *string    `json:"reference_script_hash"`
+	ConsumedByTx        *string    `json:"consumed_by_tx"`
 }
 type TransactionUTXOs struct {
 	// Transaction hash

--- a/client.go
+++ b/client.go
@@ -72,8 +72,10 @@ type APIClient interface {
 	MetricsEndpoints(ctx context.Context) ([]MetricsEndpoint, error)
 	Block(ctx context.Context, hashOrNumber string) (Block, error)
 	BlockLatest(ctx context.Context) (Block, error)
-	BlockLatestTransactions(ctx context.Context) ([]Transaction, error)
-	BlockTransactions(ctx context.Context, hashOrNumer string) ([]Transaction, error)
+	BlockLatestTransactions(ctx context.Context, query APIQueryParams) ([]Transaction, error)
+	BlockLatestTransactionsAll(ctx context.Context) <-chan BlockTransactionResult
+	BlockTransactions(ctx context.Context, hashOrNumer string, query APIQueryParams) ([]Transaction, error)
+	BlockTransactionsAll(ctx context.Context, hashOrNumber string) <-chan BlockTransactionResult
 	BlocksNext(ctx context.Context, hashOrNumber string) ([]Block, error)
 	BlocksPrevious(ctx context.Context, hashOrNumber string) ([]Block, error)
 	BlockBySlot(ctx context.Context, slotNumber int) (Block, error)
@@ -122,14 +124,20 @@ type APIClient interface {
 	AccountAssociatedAddressesAll(ctx context.Context, stakeAddress string) <-chan AccountAssociatedAddressesAll
 	AccountAssociatedAssets(ctx context.Context, stakeAddress string, query APIQueryParams) ([]AccountAssociatedAsset, error)
 	AccountAssociatedAssetsAll(ctx context.Context, stakeAddress string) <-chan AccountAssociatedAssetsAll
+	AccountAddressesTotal(ctx context.Context, stakeAddress string) (AccountAddressesTotal, error)
+	AccountTransactions(ctx context.Context, stakeAddress string, query APIQueryParams) ([]AccountTransaction, error)
+	AccountTransactionsAll(ctx context.Context, stakeAddress string) <-chan AccountTransactionResult
 	Asset(ctx context.Context, asset string) (Asset, error)
 	Assets(ctx context.Context, query APIQueryParams) ([]AssetByPolicy, error)
 	AssetsAll(ctx context.Context) <-chan AssetByPolicyResult
-	AssetHistory(ctx context.Context, asset string) ([]AssetHistory, error)
-	AssetTransactions(ctx context.Context, asset string) ([]AssetTransaction, error)
+	AssetHistory(ctx context.Context, asset string, query APIQueryParams) ([]AssetHistory, error)
+	AssetHistoryAll(ctx context.Context, asset string) <-chan AssetHistoryResult
+	AssetTransactions(ctx context.Context, asset string, query APIQueryParams) ([]AssetTransaction, error)
+	AssetTransactionsAll(ctx context.Context, asset string) <-chan AssetTransactionResult
 	AssetAddresses(ctx context.Context, asset string, query APIQueryParams) ([]AssetAddress, error)
 	AssetAddressesAll(ctx context.Context, asset string) <-chan AssetAddressesAll
-	AssetsByPolicy(ctx context.Context, policyId string) ([]AssetByPolicy, error)
+	AssetsByPolicy(ctx context.Context, policyId string, query APIQueryParams) ([]AssetByPolicy, error)
+	AssetsByPolicyAll(ctx context.Context, policyId string) <-chan AssetByPolicyResult
 	Genesis(ctx context.Context) (GenesisBlock, error)
 	Mempool(ctx context.Context, query APIQueryParams) ([]Mempool, error)
 	MempoolAll(ctx context.Context) <-chan MempoolResult
@@ -143,6 +151,7 @@ type APIClient interface {
 	MetadataTxContentInCBOR(ctx context.Context, label string, query APIQueryParams) ([]MetadataTxContentInCBOR, error)
 	MetadataTxContentInCBORAll(ctx context.Context, label string) <-chan MetadataTxContentInCBORResult
 	Network(ctx context.Context) (NetworkInfo, error)
+	NetworkEras(ctx context.Context) ([]NetworkEra, error)
 	Nutlink(ctx context.Context, address string) (NutlinkAddress, error)
 	Tickers(ctx context.Context, address string, query APIQueryParams) ([]Ticker, error)
 	TickersAll(ctx context.Context, address string) <-chan TickerResult
@@ -155,6 +164,10 @@ type APIClient interface {
 	ScriptsAll(ctx context.Context) <-chan ScriptAllResult
 	ScriptRedeemers(ctx context.Context, address string, query APIQueryParams) ([]ScriptRedeemer, error)
 	ScriptRedeemersAll(ctx context.Context, address string) <-chan ScriptRedeemerResult
+	ScriptJSON(ctx context.Context, scriptHash string) (ScriptJSON, error)
+	ScriptCBOR(ctx context.Context, scriptHash string) (ScriptCBOR, error)
+	ScriptDatum(ctx context.Context, datumHash string) (ScriptDatum, error)
+	ScriptDatumCBOR(ctx context.Context, datumHash string) (ScriptDatumCBOR, error)
 	Pool(ctx context.Context, poolID string) (Pool, error)
 	Pools(ctx context.Context, query APIQueryParams) (Pools, error)
 	PoolsAll(ctx context.Context) <-chan PoolsResult
@@ -172,6 +185,27 @@ type APIClient interface {
 	PoolBlocksAll(ctx context.Context, poolId string) <-chan PoolBlocksResult
 	PoolUpdates(ctx context.Context, poolID string, query APIQueryParams) ([]PoolUpdate, error)
 	PoolUpdatesAll(ctx context.Context, poolId string) <-chan PoolUpdateResult
+	PoolsExtended(ctx context.Context, query APIQueryParams) ([]PoolExtended, error)
+	PoolsExtendedAll(ctx context.Context) <-chan PoolsExtendedResult
+	Dreps(ctx context.Context, query APIQueryParams) ([]Drep, error)
+	DrepsAll(ctx context.Context) <-chan DrepResult
+	DrepDetails(ctx context.Context, drepId string) (DrepDetails, error)
+	DrepMetadata(ctx context.Context, drepId string) (DrepMetadata, error)
+	DrepDelegators(ctx context.Context, drepId string, query APIQueryParams) ([]DrepDelegator, error)
+	DrepDelegatorsAll(ctx context.Context, drepId string) <-chan DrepDelegatorResult
+	DrepUpdates(ctx context.Context, drepId string, query APIQueryParams) ([]DrepUpdate, error)
+	DrepUpdatesAll(ctx context.Context, drepId string) <-chan DrepUpdateResult
+	DrepVotes(ctx context.Context, drepId string, query APIQueryParams) ([]DrepVote, error)
+	DrepVotesAll(ctx context.Context, drepId string) <-chan DrepVoteResult
+	Proposals(ctx context.Context, query APIQueryParams) ([]Proposal, error)
+	ProposalsAll(ctx context.Context) <-chan ProposalResult
+	Proposal(ctx context.Context, txHash string, certIndex int) (ProposalDetails, error)
+	ProposalParameters(ctx context.Context, txHash string, certIndex int) (ProposalParameters, error)
+	ProposalMetadata(ctx context.Context, txHash string, certIndex int) (ProposalMetadata, error)
+	ProposalWithdrawals(ctx context.Context, txHash string, certIndex int, query APIQueryParams) ([]ProposalWithdrawal, error)
+	ProposalWithdrawalsAll(ctx context.Context, txHash string, certIndex int) <-chan ProposalWithdrawalResult
+	ProposalVotes(ctx context.Context, txHash string, certIndex int, query APIQueryParams) ([]ProposalVote, error)
+	ProposalVotesAll(ctx context.Context, txHash string, certIndex int) <-chan ProposalVoteResult
 	Transaction(ctx context.Context, hash string) (TransactionContent, error)
 	TransactionCBOR(ctx context.Context, hash string) (TransactionCBOR, error)
 	TransactionUTXOs(ctx context.Context, hash string) (TransactionUTXOs, error)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	Major      = 0
-	Minor      = 3
+	Minor      = 4
 	Patch      = 0
 	Prerelease = ""
 )


### PR DESCRIPTION
## Summary

Comprehensive update to align blockfrost-go SDK with Blockfrost OpenAPI v0.1.86.

### New endpoints
- **Conway Governance**: `Dreps`, `DrepsAll`, `DrepDetails`, `DrepMetadata`, `DrepDelegators`, `DrepDelegatorsAll`, `DrepUpdates`, `DrepUpdatesAll`, `DrepVotes`, `DrepVotesAll`, `Proposals`, `ProposalsAll`, `Proposal`, `ProposalParameters`, `ProposalMetadata`, `ProposalWithdrawals`, `ProposalWithdrawalsAll`, `ProposalVotes`, `ProposalVotesAll`
- **Network**: `NetworkEras`
- **Pools**: `PoolsExtended`, `PoolsExtendedAll`
- **Scripts**: `ScriptJSON`, `ScriptCBOR`, `ScriptDatum`, `ScriptDatumCBOR`
- **Accounts**: `AccountAddressesTotal`, `AccountTransactions`, `AccountTransactionsAll`

### New paginated `*All` variants
- `AssetHistoryAll`, `AssetTransactionsAll`, `AssetsByPolicyAll`
- `BlockTransactionsAll`, `BlockLatestTransactionsAll`

### Updated structs (new fields from OpenAPI spec)
- `Account`: added `DrepId`, `Registered`
- `AccountDelegationHistory`, `AccountRegistrationHistory`, `AccountWithdrawalHistory`, `AccountMIRHistory`: added `TxSlot`, `BlockTime`, `BlockHeight`
- `EpochParameters`: added 24 Conway governance parameters (`CostModelsRaw`, `PvtMotionNoConfidence`, `DvtMotionNoConfidence`, `GovActionDeposit`, `DrepDeposit`, `DrepActivity`, `MinFeeRefScriptCostPerByte`, etc.)
- `TransactionContent`: added `TreasuryDonation`
- `TransactionOutput`: added `ConsumedByTx`
- `Pool`: added `CalidusKey`
- `PoolMetadata`: added `Error`

### Breaking changes

> ⚠️ **Users of these APIs will need to update their code.**

- `AssetHistory`, `AssetTransactions`, `AssetsByPolicy` now accept `APIQueryParams` parameter (needed for pagination)
- `BlockTransactions`, `BlockLatestTransactions` now accept `APIQueryParams` parameter
- **`TransactionPoolRetirementCerts`** now returns `[]TransactionPoolRetires` instead of `[]TransactionPoolCert` — the previous return type was incorrect and produced zero-valued structs since the JSON fields didn't match

### Bug fixes
- **`TransactionPoolUpdates`** was hitting `/txs/{hash}/delegations` instead of `/txs/{hash}/pool_updates` (copy-paste bug) — it was a broken duplicate of `TransactionDelegationCerts`. Now correctly hits `/txs/{hash}/pool_updates`, making it functionally identical to `TransactionPoolUpdateCerts`
- **`TransactionPoolRetirementCerts`** was deserializing into `TransactionPoolCert` (pool update structure) instead of `TransactionPoolRetires` (retirement structure with `cert_index`, `pool_id`, `retiring_epoch`) — silently producing zero-valued fields
- Fixed `Quantity` JSON serialization to marshal as number instead of string on the wire (fixes `TransactionEvaluateUTXOs` API errors)
- Fixed duplicate CI pipeline triggers for feature branch PRs
- Updated tests to use tx hashes that actually contain pool updates/retirements (previous test fixtures returned empty arrays, hiding both bugs above)

### Version
Bumped to 0.4.0

## Test plan
- [x] All existing integration tests pass on mainnet
- [x] Governance endpoints verified on mainnet (DReps and Proposals)
- [x] New `*All` pagination methods verified on mainnet
- [x] `Quantity` serialization fix verified with `TransactionEvaluateUTXOs`
- [x] `TransactionPoolUpdates` / `TransactionPoolUpdateCerts` return real pool update data
- [x] `TransactionPoolRetirementCerts` returns real pool retirement data
- [x] New endpoints tested with golden file comparison (Scripts, NetworkEras, BlockTransactionsAll)

🤖 Generated with [Claude Code](https://claude.com/claude-code)